### PR TITLE
Fix : remove double quotes from searched words :

### DIFF
--- a/src/app/components/search/search.component.ts
+++ b/src/app/components/search/search.component.ts
@@ -125,7 +125,7 @@ export class SearchComponent {
     }
     if (event.keyCode === 13) {
       if (this.searchCtrl.value && this.searchCtrl.value.trim() !== '' ) {
-        this.valuesChangedEvent.next('"' + this.searchCtrl.value + '"');
+        this.valuesChangedEvent.next(this.searchCtrl.value);
       }
     }
   }


### PR DESCRIPTION
- Only directly searched words are concerned (without using autocompletion)

Fix #85 