### PR TITLE
Copy lock file before build in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM node:8-alpine as builder
 
 COPY ./package.json  ./
+COPY ./package-lock.json  ./
 
 RUN npm set progress=false && npm config set depth 0 && npm cache clean --force
 


### PR DESCRIPTION
To avoid an integrity checksum error after build the app 