### PR TITLE
fix: remove border box

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,10 +22,6 @@
   src: local('Material Icons'), local('MaterialIcons-Regular'), url('./assets/fonts/material-icons.woff2') format('woff2')
 }
 
-*, ::after, ::before {
-  box-sizing: border-box;
-}
-
 body {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
This PR aims to remove the globally defined box sizing of ARLAS WUI. This sizing is not the value by default and can have heavy impacts on how sizes are computed.

For instance, with the value currently used, borders and paddings are included in the width, meaning that specifying a width of 250px with 4px of padding on either side and a 1px border, will result in an effective size of 240px instead of the one specified.

Using the default value allows for the paddings and border sizes to be **added** to the desired width, allowing for components sizes to be more easily defined.

If one component needs the box-sizing value to be border-box, then such a choice has to be made **locally**, as to not to impact the rest of the app.

_Summary of the conversation with Mohamed_