### PR TITLE
feat: ergo menu

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,7 +37,6 @@
             [class.app-container-with-list]="rightListContributors.length > 0 && !listOpen && resultListConfigPerContId.get(previewListContrib.identifier)?.hasGridMode && analyticsService.activeTab === undefined"
             [class.app-container-reduce-analytics]="listOpen && analyticsService.activeTab !== undefined"
             [class.app-container-with-list-analytics]="rightListContributors.length > 0 && !listOpen && resultListConfigPerContId.get(previewListContrib.identifier)?.hasGridMode && analyticsService.activeTab !== undefined">
-            <arlas-bookmark-menu *ngIf="!arlasStartUpService.emptyMode"></arlas-bookmark-menu>
 
             <div id="arlas-map-settings" class="arlas-map-settings" *ngIf="!arlasStartUpService.emptyMode" >
               <div class="arlas-map-settings-container" >

--- a/src/app/components/left-menu/left-menu.component.html
+++ b/src/app/components/left-menu/left-menu.component.html
@@ -8,48 +8,56 @@
     </mat-list-item>
   </mat-nav-list>
   <mat-divider></mat-divider>
-  <arlas-analytics-menu [showIndicators]="showIndicators"></arlas-analytics-menu>
-  <mat-divider></mat-divider>
-  <button mat-icon-button class="arlas-analytics-refresh" [hidden]="!isRefreshAnalyticsButton" (click)="refreshComponents()"
-    matTooltip="{{'Refresh components' | translate}}">
-    <mat-icon>refresh</mat-icon>
-  </button>
-  <div class="action-list">
-    <arlas-tool-link></arlas-tool-link>
-    <mat-divider *ngIf="shareComponentConfig || downloadComponentConfig || tagComponentConfig"></mat-divider>
-    <mat-nav-list>
-      <mat-list-item *ngIf="shareComponentConfig" matTooltip="{{'Share geographical data' | translate}}"
-        (click)="displayShare()">
-        <button mat-icon-button>
-          <mat-icon>share</mat-icon>
-        </button>
-      </mat-list-item>
-      <mat-list-item *ngIf="downloadComponentConfig" (click)="displayDownload()"
-        matTooltip="{{ 'Download data' | translate }}">
-        <button mat-icon-button>
-          <mat-icon>get_app</mat-icon>
-        </button>
-      </mat-list-item>
-      <mat-list-item *ngIf="tagComponentConfig" [matMenuTriggerFor]="tagMenu" matTooltip="{{ 'Tag data' | translate }}">
-        <button mat-icon-button>
-          <mat-icon>local_offer</mat-icon>
-        </button>
-      </mat-list-item>
-    </mat-nav-list>
+  <div class="arlas-analytics">
+    <arlas-analytics-menu [showIndicators]="showIndicators"></arlas-analytics-menu>
     <mat-divider></mat-divider>
-    <mat-nav-list>
-      <mat-list-item *ngIf="this.walkthroughService.isActivable" (click)="replayTour()"
-        matTooltip="{{ 'Replay tour' | translate }}">
-        <button mat-icon-button>
-          <mat-icon>slideshow</mat-icon>
-        </button>
-      </mat-list-item>
-    </mat-nav-list>
+    <ng-container *ngIf="isRefreshAnalyticsButton">
+      <button mat-icon-button class="arlas-analytics-refresh" (click)="refreshComponents()"
+        matTooltip="{{'Refresh components' | translate}}">
+        <mat-icon>refresh</mat-icon>
+      </button>
+      <mat-divider></mat-divider>
+    </ng-container>
+  </div>
+  
+  <div class="action-list">
+    <mat-divider></mat-divider>
+    <arlas-tool-link></arlas-tool-link>
+    <button mat-icon-button [matMenuTriggerFor]="actionMenu" class="action-menu-button">
+      <mat-icon>more_vert</mat-icon>
+    </button>
+    <mat-menu #actionMenu="matMenu">
+      <button mat-menu-item *ngIf="shareComponentConfig" (click)="displayShare()">
+        <mat-icon>share</mat-icon>
+        <span>{{ 'Share geographical data' | translate }}</span>
+      </button>
+      <button mat-menu-item *ngIf="downloadComponentConfig" (click)="displayDownload()">
+        <mat-icon>get_app</mat-icon>
+        <span>{{ 'Download data' | translate }}</span>
+      </button>
+      <button mat-menu-item [matMenuTriggerFor]="bookmarkMenu.matMenu" *ngIf="!arlasStartUpService.emptyMode">
+        <mat-icon>bookmark</mat-icon>
+        <span>{{ 'Bookmark' | translate }}</span>
+      </button>
+      <button mat-menu-item *ngIf="tagComponentConfig" [matMenuTriggerFor]="tagMenu">
+        <mat-icon>local_offer</mat-icon>
+        <span>{{ 'Tag data' | translate }}</span>
+      </button>
+      <button mat-menu-item *ngIf="this.walkthroughService.isActivable" (click)="replayTour()">
+        <mat-icon>slideshow</mat-icon>
+        <span>{{ 'Replay tour' | translate }}</span>
+      </button>
+    </mat-menu>
   </div>
 </div>
 <arlas-share #share [icon]="'share'" [hidden]="true"></arlas-share>
+
 <arlas-download #download [collections]="collections" [hidden]="true"></arlas-download>
+
+<arlas-bookmark-menu #bookmarkMenu></arlas-bookmark-menu>
+
 <arlas-tag #tag></arlas-tag>
+
 <mat-menu #tagMenu="matMenu">
   <button mat-menu-item (click)="displayTag()">
     <mat-icon>add_circle_outline</mat-icon>

--- a/src/app/components/left-menu/left-menu.component.scss
+++ b/src/app/components/left-menu/left-menu.component.scss
@@ -18,8 +18,23 @@
     display: none;
   }
 
-  .arlas-analytics-refresh {
-    align-self: center;
+  .arlas-analytics {
+    display: flex;
+    flex-direction: column;
+
+    .arlas-analytics-refresh {
+      align-self: center;
+    }
+  }
+
+  .action-list {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    .action-menu-button {
+      align-self: center;
+    }
   }
 }
 

--- a/src/app/components/left-menu/left-menu.component.ts
+++ b/src/app/components/left-menu/left-menu.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import {
   ArlasCollaborativesearchService,
-  ArlasConfigService, ArlasSettingsService, ArlasWalkthroughService, AuthentificationService,
+  ArlasConfigService, ArlasSettingsService, ArlasStartupService, ArlasWalkthroughService, AuthentificationService,
   DownloadComponent, PersistenceService, ShareComponent, TagComponent, UserInfosComponent
 } from 'arlas-wui-toolkit';
 import { Subject } from 'rxjs';
@@ -60,10 +60,15 @@ export class LeftMenuComponent implements OnInit {
 
   public isRefreshAnalyticsButton: any;
 
-  public constructor(private authentService: AuthentificationService, private translate: TranslateService,
-    public persistenceService: PersistenceService, private configService: ArlasConfigService,
-    public walkthroughService: ArlasWalkthroughService, private collaborativeService: ArlasCollaborativesearchService,
-    public settings: ArlasSettingsService
+  public constructor(
+    private authentService: AuthentificationService,
+    private translate: TranslateService,
+    public persistenceService: PersistenceService,
+    public walkthroughService: ArlasWalkthroughService,
+    public settings: ArlasSettingsService,
+    public arlasStartUpService: ArlasStartupService,
+    public collaborativeService: ArlasCollaborativesearchService,
+    public configService: ArlasConfigService
   ) {
     this.window = window;
     this.reduce = this.translate.instant('reduce');


### PR DESCRIPTION
![image](https://github.com/gisaia/ARLAS-wui/assets/104018401/251a3de6-fd44-40de-b75f-39fb3c29ce95)

For now, I kept the 'Switch dashboard' button. I think it could have a utility during development phases when ARLAS-wui is not linked to an ARLAS hub to easily switch dashboards. 