### PR TITLE
Feat: configure datepicker according timeline config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "dependencies": {
         "@colsen1991/ngx-translate-extract-marker": "^3.0.1",
         "@ngx-translate/core": "^17.0.0",
-        "arlas-wui-toolkit": "^28.0.1",
+        "arlas-wui-toolkit": "^28.0.2",
         "hammerjs": "^2.0.8",
         "ng-packagr": "^21.2.2",
         "ngx-markdown": "~21.1.0",
@@ -6543,9 +6543,9 @@
       }
     },
     "node_modules/arlas-map": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/arlas-map/-/arlas-map-28.0.1.tgz",
-      "integrity": "sha512-p8QUXdgjotAWZfmtAUiQ6KsFg1YE4HcjjxOwfwsIAvRIKLjow68bwmsLOImsszoLKNKFFYt35DgkExL2n4FdiQ==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/arlas-map/-/arlas-map-28.0.2.tgz",
+      "integrity": "sha512-Jmq5s9VBfJTSjFsBTbatDJWNhq3/jDLFocQP/FDQ6EuIinjRPe8AZddsio2QClWXmsPOuRKXxD0XBmH9W6mtrw==",
       "dependencies": {
         "@mapbox/mapbox-gl-draw": "^1.4.3",
         "@mapbox/mapbox-gl-draw-static-mode": "^1.0.1",
@@ -6564,7 +6564,7 @@
         "@turf/rhumb-destination": "^7.3.0",
         "@turf/transform-rotate": "^7.3.0",
         "@turf/transform-translate": "^7.3.0",
-        "arlas-web-components": "28.0.1",
+        "arlas-web-components": "28.0.2",
         "betterknown": "^1.2.0",
         "geojson-polygon-self-intersections": "1.2.1",
         "geojson-validation": "0.2.1",
@@ -6592,11 +6592,11 @@
       }
     },
     "node_modules/arlas-mapbox": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/arlas-mapbox/-/arlas-mapbox-28.0.1.tgz",
-      "integrity": "sha512-eXAt/WD9xBQyLdmLPoNQjLomoJELQVZIJapp9PMGcGP7PHgtGNrawJsPV8SBBjTlZc1Z4pP5vP+gnWxP44qI8A==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/arlas-mapbox/-/arlas-mapbox-28.0.2.tgz",
+      "integrity": "sha512-7VAYE/PDp4dhqBFTYiq7di9R6qfZNf5tz99DQgLeuwM2iULIdvYbRNBfKa8GIswXSjrlEVjp2HiKGAVRhbzpqA==",
       "dependencies": {
-        "arlas-map": "28.0.1",
+        "arlas-map": "28.0.2",
         "mapbox-gl": "^1.6.1",
         "tslib": "^2.3.0"
       },
@@ -6617,11 +6617,11 @@
       }
     },
     "node_modules/arlas-maplibre": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/arlas-maplibre/-/arlas-maplibre-28.0.1.tgz",
-      "integrity": "sha512-tN/enVsauPpym7xVDEGlhi2QBMPobn6ZSYRi1ulu491cDMs+aAgOXPH0TS+HH7RoPb1dzwjZr+8vnTOcS+RIAA==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/arlas-maplibre/-/arlas-maplibre-28.0.2.tgz",
+      "integrity": "sha512-tZvkOasmLF5FQwdmCEhDPkiXIwrlOXbw2gsEAJJLhfcxrlPmJYFLQ9EZnOn4pFKgmTFHrWYEae37B/Rb+8e4lQ==",
       "dependencies": {
-        "arlas-map": "28.0.1",
+        "arlas-map": "28.0.2",
         "maplibre-gl": "^5.21.0",
         "tslib": "^2.3.0"
       },
@@ -6670,9 +6670,9 @@
       }
     },
     "node_modules/arlas-web-components": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/arlas-web-components/-/arlas-web-components-28.0.1.tgz",
-      "integrity": "sha512-adsfizMa+j6jz6w5ERtt9GSoswX1F2ijyyR5YRdMewUgdYG/JEzkIHSY99zEHbFVWAMvEnU+je7T6oTepkFObw==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/arlas-web-components/-/arlas-web-components-28.0.2.tgz",
+      "integrity": "sha512-Zc6h6joshy9S05cqGHvID8haTdcMYtrCQeSyL7XNhKlHYnlVGUTCxizv6IlqKA1Kv4pzwEzRv3EVVv5aBcP5qg==",
       "dependencies": {
         "arlas-d3": "^28.0.0",
         "iv-viewer": "^2.2.1",
@@ -6751,9 +6751,9 @@
       "link": true
     },
     "node_modules/arlas-wui-toolkit": {
-      "version": "28.0.1",
-      "resolved": "https://registry.npmjs.org/arlas-wui-toolkit/-/arlas-wui-toolkit-28.0.1.tgz",
-      "integrity": "sha512-btGADQmaADl2BuBvErEgit6ubzEImHBERXbPBLzHSDb65sCgMIcd3WHaGwcMuita6DlK4utwbDzQyiJeMSVJJg==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/arlas-wui-toolkit/-/arlas-wui-toolkit-28.0.2.tgz",
+      "integrity": "sha512-mvaZS+8NN0iXAGmxCl3Wx/6xNL6Dq97MdbatXZFcKpUu1rrWIpXX94CAIt13KjCSqDppd4ZngAiX2SYuxemvfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@danielmoncada/angular-datetime-picker": "^21.0.0",
@@ -6765,11 +6765,11 @@
         "angular-oauth2-oidc": "^20.0.2",
         "angular-oauth2-oidc-jwks": "^20.0.0",
         "arlas-iam-api": "^28.0.1",
-        "arlas-map": "^28.0.1",
+        "arlas-map": "^28.0.2",
         "arlas-permissions-api": "^28.0.0",
         "arlas-persistence-api": "^28.0.0",
         "arlas-tagger-api": "^28.0.0",
-        "arlas-web-components": "^28.0.1",
+        "arlas-web-components": "^28.0.2",
         "arlas-web-contributors": "^28.0.0",
         "cli-color": "^1.2.0",
         "fetch-intercept": "^2.3.1",
@@ -14615,9 +14615,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15622,7 +15622,7 @@
       "name": "arlas-wui-cloud",
       "license": "Apache-2.0",
       "dependencies": {
-        "arlas-mapbox": "^28.0.1"
+        "arlas-mapbox": "^28.0.2"
       },
       "peerDependencies": {
         "@angular/animations": "^21.2.7",
@@ -15643,7 +15643,7 @@
       "name": "arlas-wui",
       "license": "Apache-2.0",
       "dependencies": {
-        "arlas-maplibre": "^28.0.1"
+        "arlas-maplibre": "^28.0.2"
       },
       "peerDependencies": {
         "@angular/animations": "^21.2.7",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@colsen1991/ngx-translate-extract-marker": "^3.0.1",
     "@ngx-translate/core": "^17.0.0",
-    "arlas-wui-toolkit": "^28.0.1",
+    "arlas-wui-toolkit": "^28.0.2",
     "hammerjs": "^2.0.8",
     "ng-packagr": "^21.2.2",
     "ngx-markdown": "~21.1.0",

--- a/packages/cloud/package.json
+++ b/packages/cloud/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "arlas-mapbox": "^28.0.1"
+    "arlas-mapbox": "^28.0.2"
   },
   "peerDependencies": {
     "@angular/animations": "^21.2.7",

--- a/packages/opensource/package.json
+++ b/packages/opensource/package.json
@@ -7,7 +7,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "arlas-maplibre": "^28.0.1"
+    "arlas-maplibre": "^28.0.2"
   },
   "peerDependencies": {
     "@angular/animations": "^21.2.7",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
+  ARLAS_DATE_TIME_FORMATS,
   ArlasCollectionService,
   ArlasConfigService,
   ArlasIamService,
@@ -31,9 +32,11 @@ import {
   ArlasToolkitSharedModule,
   ArlasWalkthroughModule,
   AuthentificationService,
+  DEFAULT_OWL_DATE_TIME_FORMATS_VALUE,
   JwtInterceptor,
   PersistenceService,
-  WalkthroughLoader
+  WalkthroughLoader,
+  ARLAS_OWL_MOMENT_ADAPTER_OPTIONS_OVERRIDE
 } from 'arlas-wui-toolkit';
 import { LAZYLOAD_IMAGE_HOOKS } from 'ng-lazyload-image';
 import { AppRoutingModule } from './app-routing.module';
@@ -53,6 +56,50 @@ import { ResultlistService } from './services/resultlist.service';
 import { VisualizeService } from './services/visualize.service';
 import { ArlasTranslateLoader, ArlasWalkthroughLoader } from './tools/customLoader';
 import { LazyLoadImageHooks } from './tools/lazy-loader';
+import { OwlDateTimeFormats } from '@danielmoncada/angular-datetime-picker';
+import { OwlMomentDateTimeAdapterOptions } from '@danielmoncada/angular-datetime-picker-moment-adapter';
+
+
+export const MY_CUSTOM_FORMATS_FR = {
+  parseInput: 'DD MMM YYYY HH:mm:ss',
+  fullPickerInput: 'DD MMM yyyy HH:mm:ss',
+  datePickerInput: 'DD MMM YYYY HH:mm:ss',
+  timePickerInput: 'HH:mm:ss',
+  monthYearLabel: 'MMM YYYY',
+  dateA11yLabel: 'LL',
+  monthYearA11yLabel: 'MMMM YYYY'
+};
+
+export const MY_CUSTOM_FORMATS_EN = {
+  parseInput: 'MMM DD YYYY HH:mm:ss',
+  fullPickerInput: 'MMM DD YYYY HH:mm:ss',
+  datePickerInput: 'MMM DD YYYY HH:mm:ss',
+  timePickerInput: 'HH:mm:ss',
+  monthYearLabel: 'MMM YYYY',
+  dateA11yLabel: 'LL',
+  monthYearA11yLabel: 'MMMM YYYY'
+};
+
+export function getOwlDateFormatFactory(configService: ArlasConfigService): OwlDateTimeFormats {
+  const format = (configService.getConfig() as any)?.arlas?.web?.components?.timeline?.input?.ticksDateFormat;
+  // '%d %b %Y  %H:%M' and '%b %d %Y  %H:%M' are the two formats available in the builder, the first for FR the second for ENG
+  if (format === '%d %b %Y  %H:%M') {
+    return MY_CUSTOM_FORMATS_FR;
+  } else if (format === '%b %d %Y  %H:%M') {
+    return MY_CUSTOM_FORMATS_EN;
+  } else {
+    return DEFAULT_OWL_DATE_TIME_FORMATS_VALUE;
+  }
+}
+
+export function getOwlMomentAdapterFactory(configService: ArlasConfigService): Partial<OwlMomentDateTimeAdapterOptions> {
+  const useUtc = (configService.getConfig() as any)?.arlas?.web?.contributors?.find((c: any) => c.name === 'Timeline')?.useUtc;
+  if (!!useUtc) {
+    return { useUtc };
+  } else {
+    return { useUtc: false };
+  }
+}
 
 const COMPONENTS = [
   ArlasWuiComponent,
@@ -103,6 +150,16 @@ const COMPONENTS = [
       useClass: JwtInterceptor,
       deps: [AuthentificationService, ArlasIamService, ArlasSettingsService],
       multi: true
+    },
+    {
+      provide: ARLAS_DATE_TIME_FORMATS,
+      useFactory: getOwlDateFormatFactory,
+      deps: [ArlasConfigService]
+    },
+    {
+      provide: ARLAS_OWL_MOMENT_ADAPTER_OPTIONS_OVERRIDE,
+      useFactory: getOwlMomentAdapterFactory,
+      deps: [ArlasConfigService]
     },
     ArlasCollectionService,
     ContributorService,

--- a/src/config.json
+++ b/src/config.json
@@ -670,6 +670,7 @@
             "dataType": "time",
             "isHistogramSelectable": true,
             "ticksDateFormat": "%b %d %Y  %H:%M",
+            "valuesDateFormat": "%b %d %Y  %H:%M",
             "chartType": "bars",
             "chartHeight": 128,
             "chartWidth": null,
@@ -900,6 +901,7 @@
             "dataType": "time",
             "isHistogramSelectable": true,
             "ticksDateFormat": "%b %d %Y  %H:%M",
+            "valuesDateFormat": "%b %d %Y  %H:%M",
             "chartType": "bars",
             "chartHeight": 60,
             "chartWidth": null,
@@ -1241,6 +1243,7 @@
                 "barWeight": 0.8,
                 "dataType": "time",
                 "ticksDateFormat": "%d %b %Y  %H:%M",
+                "valuesDateFormat": "%d %b %Y  %H:%M",
                 "customizedCssClass": "arlas-timeline-analytics",
                 "isSmoothedCurve": false
               },


### PR DESCRIPTION
- Fix https://github.com/gisaia/ARLAS-wui-toolkit/issues/822

Need new toolkit:

- The datepicker input field has the format of the timeline (FR or EN style)
- Bug fix about useUtc, and use utc info from contributor